### PR TITLE
Invalid Date Chrome Fix

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -93,7 +93,7 @@
 			}
 			else
 			{
-				if(typeof(this.$element.attr('value')) !== 'undefined' && this.$element.attr('value') !== null)
+				if(typeof(this.$element.attr('value')) !== 'undefined' && this.$element.attr('value') !== null && this.$element.attr('value') !== "")
 				{
 					if(typeof(this.$element.attr('value')) === 'string')
 					{


### PR DESCRIPTION
I've encountered an error while using your plugin. After is initialized, it won't work properly since it takes the value attribute from the element as an empty string (""), causing an error on moment which returns Invalid Date error.