### PR TITLE
Fix dialog keep showing after init

### DIFF
--- a/css/bootstrap-material-datetimepicker.css
+++ b/css/bootstrap-material-datetimepicker.css
@@ -49,7 +49,7 @@
 
 .dtp .dtp-buttons { padding: 0 1rem 1rem 1rem; text-align: right; }
 
-.dtp .hidden { display: none; }
+.dtp.hidden, .dtp .hidden { display: none; }
 .dtp .invisible { visibility: hidden; }
 
 .dtp .left { float: left; }


### PR DESCRIPTION
When using css framework that without `.hidden` class, the dialog will show after init and cannot close.