### PR TITLE
[gh-pages] Fixed not being able to tab into input

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -64,7 +64,7 @@
 			this._attachEvent(this.$dtpElement.find('.dtp-content'), 'click', this._onElementClick.bind(this));
 			this._attachEvent(this.$dtpElement, 'click', this._onBackgroundClick.bind(this));
 			this._attachEvent(this.$dtpElement.find('.dtp-close > a'), 'click', this._onCloseClick.bind(this));
-			this._attachEvent(this.$element, 'click', this._onClick.bind(this));
+			this._attachEvent(this.$element, 'focus', this._onClick.bind(this));
 		},
 		initDays: function()
 		{


### PR DESCRIPTION
I encountered an issue where (when filling out a form) I couldn't `tab` into the input and get the datepicker to show. Changing the event to `focus` not only preserves the ability to `click` the input but also fixes the issue of not being able to tab into the input.

Let me know if you require modifications.

Cheers,

Ben  