### PR TITLE
Fix auto resize when month has 6 weeks.

### DIFF
--- a/css/bootstrap-material-datetimepicker.css
+++ b/css/bootstrap-material-datetimepicker.css
@@ -16,7 +16,7 @@
 .dtp .dtp-close > a { color: #fff; }
 .dtp .dtp-close > a > i { font-size: 1em; }
 
-.dtp table.dtp-picker-days { margin: 0; }
+.dtp table.dtp-picker-days { margin: 0; min-height: 251px;}
 .dtp table.dtp-picker-days, .dtp table.dtp-picker-days tr, .dtp table.dtp-picker-days tr > td { border: none; }
 .dtp table.dtp-picker-days tr > td {  font-weight: 700; font-size: 1.2rem; text-align: center; padding: 1rem 0.3rem; }
 .dtp table.dtp-picker-days tr > td > span.dtp-select-day { color: #BDBDBD!important; }


### PR DESCRIPTION
Fix changing height when month has 6 weeks. It is better to show a fixed (with the greater height) than to keep shrinking/growing the whole component.