### PR TITLE
Fixed _centerBox() never firing on window resize

### DIFF
--- a/css/bootstrap-material-datetimepicker.css
+++ b/css/bootstrap-material-datetimepicker.css
@@ -1,5 +1,5 @@
 .dtp { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.4); z-index: 2000; font-size: 15px; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; }
-.dtp > .dtp-content { background: #fff; max-width: 300px; box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12); max-height: 500px; position: relative; left: 50%; }
+.dtp > .dtp-content { background: #fff; max-width: 300px; box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12); max-height: 508px; position: relative; left: 50%; }
 .dtp > .dtp-content > .dtp-date-view > header.dtp-header { background: #689F38; color: #fff; text-align: center; padding: 0.3em; }
 
 .dtp div.dtp-date, .dtp div.dtp-time { background: #8BC34A; text-align: center; color: #fff; padding: 10px; }
@@ -16,7 +16,7 @@
 .dtp .dtp-close > a { color: #fff; }
 .dtp .dtp-close > a > i { font-size: 1em; }
 
-.dtp table.dtp-picker-days { margin: 0; min-height: 251px;}
+.dtp table.dtp-picker-days { margin: 0; min-height: 255px;}
 .dtp table.dtp-picker-days, .dtp table.dtp-picker-days tr, .dtp table.dtp-picker-days tr > td { border: none; }
 .dtp table.dtp-picker-days tr > td {  font-weight: 700; font-size: 0.8em; text-align: center; padding: 0.5em 0.3em; }
 .dtp table.dtp-picker-days tr > td > span.dtp-select-day { color: #BDBDBD!important; }

--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -694,7 +694,7 @@
 			if(date)
 			{
 				var minutes = (5 * Math.round(date.minute() / 5));
-				var content = ((this.params.shortTime) ? date.format('hh') : date.format('HH')) + ':' + ((minutes.toString().length == 2) ? minutes : '0' + minutes);
+				var content = ((this.params.shortTime) ? date.format('hh') : date.format('HH')) + ':' + ((minutes.toString().length == 2) ? minutes : '0' + minutes) + ((this.params.shortTime) ? ' ' + date.format('A') : '');
 
 				if(this.params.date)
 					this.$dtpElement.find('.dtp-actual-time').html(content);

--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -62,7 +62,7 @@
 
 			this.initButtons();
 
-			this._attachEvent($(window), 'resize', this._centerBox(this));
+			this._attachEvent($(window), 'resize', this._centerBox.bind(this));
 			this._attachEvent(this.$dtpElement.find('.dtp-content'), 'click', this._onElementClick.bind(this));
 			this._attachEvent(this.$dtpElement, 'click', this._onBackgroundClick.bind(this));
 			this._attachEvent(this.$dtpElement.find('.dtp-close > a'), 'click', this._onCloseClick.bind(this));


### PR DESCRIPTION
Fixed a typo (missing .bind) which caused _centerBox() to never fire
when the window resized. The box will now reposition itself to the
center of the window on resize.