### PR TITLE
_onNowClick - check for date and time options.

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -919,18 +919,29 @@
 		_onNowClick: function()
 		{
 			this.currentDate = moment();
-
-			this.showDate(this.currentDate);
-			this.showTime(this.currentDate);
-
-			switch(this.currentView)
+			
+			if(this.params.date === true)
 			{
-				case 0 : this.initDate(); break;
-				case 1 : this.initHours(); break;
-				case 2 : this.initMinutes(); break;
+				this.showDate(this.currentDate);
+				
+				if(this.currentView === 0)
+				{
+					this.initDate();
+				}
 			}
-
-			this.animateHands();
+			
+			if(this.params.time === true)
+			{
+				this.showTime(this.currentDate);
+				
+				switch(this.currentView)
+				{
+					case 1 : this.initHours(); break;
+					case 2 : this.initMinutes(); break;
+				}
+				
+				this.animateHands();
+			}
 		},
 		_onOKClick: function()
 		{


### PR DESCRIPTION
Currently, if options include `nowButton: true, time: false` and you click the "Now" button, you get:

`Uncaught TypeError: Cannot read property 'setAttribute' of undefined`
`bootstrap-material-datetimepicker.js:510`

This PR checks the options for date and time.