### PR TITLE
Revert "detects weekStart from momentjs's current locale setting"

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -3,6 +3,7 @@
 	var pluginName = "bootstrapMaterialDatePicker";
   	var pluginDataName = "plugin_" + pluginName;
   	
+  	moment.locale('en');
 
 	function Plugin(element, options)
 	{
@@ -16,14 +17,13 @@
 		this.element = element;
 		this.$element = $(element);
 
-		this.params = { date : true, time : true, format : 'YYYY-MM-DD', minDate : null, maxDate : null, currentDate : null, lang : 'en', shortTime : false, clearButton : false, nowButton : false, cancelText : 'Cancel', okText : 'OK', clearText : 'Clear', nowText : 'Now', switchOnClick : false };
+		this.params = { date : true, time : true, format : 'YYYY-MM-DD', minDate : null, maxDate : null, currentDate : null, lang : 'en', weekStart : 0, shortTime : false, clearButton : false, nowButton : false, cancelText : 'Cancel', okText : 'OK', clearText : 'Clear', nowText : 'Now', switchOnClick : false };
 		this.params = $.fn.extend(this.params, options);
 
 		this.name = "dtp_" + this.setName();
 		this.$element.attr("data-dtp", this.name);
 
 		moment.locale(this.params.lang);
-		this.params.weekStart = this.params.weekStart || moment.localeData().firstDayOfWeek();
 
 		this.init();
 	}


### PR DESCRIPTION
Reverts T00rk/bootstrap-material-datetimepicker#70

The problem is if user wants to customize it.
Weekstart is part of locale but I often see english datepickers which start at monday instead of sunday.
