### PR TITLE
Fix PM overwrite bug.

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -1063,14 +1063,15 @@
 				$(parent.find('#th-' + value)).attr('fill', '#fff');
 
 				this.currentDate.hour(parseInt(value));
-				this.showTime(this.currentDate);
-
-				this.animateHands();
 
 				if(this.params.shortTime === true && this.isPM())
 				{
-				 	dataHour += 12;
+				 	this.currentDate.add(12, 'hours');
 				}
+				
+				this.showTime(this.currentDate);
+
+				this.animateHands();
 
 				if(this.params.switchOnClick === true)
 					setTimeout(this.initMinutes.bind(this), 200);


### PR DESCRIPTION
Fix bug where PM setting is overwritten when selecting an hour.
Previous behavior: set shortTime: true, then first select the PM button, then when selecting an hour it resets to AM.
Current behavior: set shortTime: true, then first select the PM button, then when selecting an hour it persists as PM.