### PR TITLE
IE9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+### ATTENTION: 
+This version was forked to be compatible with IE9 as the Material Icons do not render in IE9. This version uses Glyphicons instead of Material Icons so you must have Bootstrap or Glyphicon font installed. 
+
 # bootstrap-material-datetimepicker
 Material DateTimePicker 
 

--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -204,27 +204,27 @@
                          '<div class="dtp-date-view">' +
                          '<header class="dtp-header">' +
                          '<div class="dtp-actual-day">Lundi</div>' +
-                         '<div class="dtp-close"><a href="javascript:void(0);"><i class="material-icons">clear</i></</div>' +
+                         '<div class="dtp-close"><a href="javascript:void(0);"><span class="glyphicon glyphicon-remove-circle"></span></</div>' +
                          '</header>' +
                          '<div class="dtp-date hidden">' +
                          '<div>' +
                          '<div class="left center p10">' +
-                         '<a href="javascript:void(0);" class="dtp-select-month-before"><i class="material-icons">chevron_left</i></a>' +
+                         '<a href="javascript:void(0);" class="dtp-select-month-before"><span class="glyphicon glyphicon-chevron-left"></span></a>' +
                          '</div>' +
                          '<div class="dtp-actual-month p80">MAR</div>' +
                          '<div class="right center p10">' +
-                         '<a href="javascript:void(0);" class="dtp-select-month-after"><i class="material-icons">chevron_right</i></a>' +
+                         '<a href="javascript:void(0);" class="dtp-select-month-after"><span class="glyphicon glyphicon-chevron-right"></span></a>' +
                          '</div>' +
                          '<div class="clearfix"></div>' +
                          '</div>' +
                          '<div class="dtp-actual-num">13</div>' +
                          '<div>' +
                          '<div class="left center p10">' +
-                         '<a href="javascript:void(0);" class="dtp-select-year-before"><i class="material-icons">chevron_left</i></a>' +
+                         '<a href="javascript:void(0);" class="dtp-select-year-before"><span class="glyphicon glyphicon-chevron-left"></span></a>' +
                          '</div>' +
                          '<div class="dtp-actual-year p80">2014</div>' +
                          '<div class="right center p10">' +
-                         '<a href="javascript:void(0);" class="dtp-select-year-after"><i class="material-icons">chevron_right</i></a>' +
+                         '<a href="javascript:void(0);" class="dtp-select-year-after"><span class="glyphicon glyphicon-chevron-right"></span></a>' +
                          '</div>' +
                          '<div class="clearfix"></div>' +
                          '</div>' +


### PR DESCRIPTION
As nice as material icons look they do not render/work in IE9. Since IE9 is still in use by millions of users it's important to continue support for it. 

Since this is a bootstrap date time picker it makes sense to use the Glyphicon package that is bundled with Bootstrap, so that no additional resources are needed. 