### PR TITLE
Add a way to programmatically fire the calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Google Material Icon Font `<link href="https://fonts.googleapis.com/icon?family=
 | **okText**		| String						| Text for the OK button (default: OK)			|
 | **clearText**		| String						| Text for the Clear button (default: Clear)	|
 | **nowText**		| String						| Text for the Now button (default: Now)		|
+| **triggerEvent**		| String						| Event to fire the calendar (default: focus)		|
+
 
 
 ### Events

--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -17,7 +17,7 @@
       this.element = element;
       this.$element = $(element);
 
-      this.params = {date: true, time: true, format: 'YYYY-MM-DD', minDate: null, maxDate: null, currentDate: null, lang: 'en', weekStart: 0, shortTime: false, clearButton: false, nowButton: false, cancelText: 'Cancel', okText: 'OK', clearText: 'Clear', nowText: 'Now', switchOnClick: false};
+       this.params = {date: true, time: true, format: 'YYYY-MM-DD', minDate: null, maxDate: null, currentDate: null, lang: 'en', weekStart: 0, shortTime: false, clearButton: false, nowButton: false, cancelText: 'Cancel', okText: 'OK', clearText: 'Clear', nowText: 'Now', switchOnClick: false, triggerEvent: 'focus'};
       this.params = $.fn.extend(this.params, options);
 
       this.name = "dtp_" + this.setName();
@@ -65,7 +65,7 @@
                  this._attachEvent(this.$dtpElement.find('.dtp-content'), 'click', this._onElementClick.bind(this));
                  this._attachEvent(this.$dtpElement, 'click', this._onBackgroundClick.bind(this));
                  this._attachEvent(this.$dtpElement.find('.dtp-close > a'), 'click', this._onCloseClick.bind(this));
-                 this._attachEvent(this.$element, 'focus', this._onFocus.bind(this));
+                 this._attachEvent(this.$element, this.params.triggerEvent, this._fireCalendar.bind(this));
               },
               initDays: function ()
               {
@@ -842,7 +842,7 @@
                     this._attachedEvents.splice(i, 1);
                  }
               },
-              _onFocus: function ()
+              _fireCalendar: function ()
               {
                  this.currentView = 0;
                  this.$element.blur();
@@ -1006,11 +1006,11 @@
 
                  if (this.params.switchOnClick === true && this.params.time === true)
                     setTimeout(this.initHours.bind(this), 200);
-                    
+
                  if(this.params.switchOnClick === true && this.params.time === false) {
                     setTimeout(this._onOKClick.bind(this), 200);
                  }
-                 
+
               },
               _onSelectHour: function (e)
               {


### PR DESCRIPTION
This PR allows one to fire the calendar using custom events, thus allowing things such as firing the calendar from a click on an icon… 
A new option was added: triggerEvent which allows to specify the name of the event that will fire the calendar. By default this option is set to focus so the previous behavior is left intact…

This should solve issues such as #95 