### PR TITLE
Allow specific days to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bootstrap-material-datetimepicker
-Material DateTimePicker 
+Material DateTimePicker
 
 Originaly designed for Bootstrap Material, the V2.0 is now completely standalone and responsive.
 
@@ -28,12 +28,12 @@ Originaly designed for Bootstrap Material, the V2.0 is now completely standalone
 | 2015-04-10		| Peterzen			| Added bower and requirejs support						 |
 | 2015-04-08		| T00rk				| Fixed problem on locale switch						 |
 | 2015-03-04		| T00rk				| Added Time picker										 |
-(\*) File names have been changed 
+(\*) File names have been changed
 
 bootstrap-material-datepicker.js => bootstrap-material-date**time**picker.js
 
 bootstrap-material-datepicker.css => bootstrap-material-date**time**picker.css
-	
+
 ### Prerequisites
 
 jquery [http://jquery.com/download/](http://jquery.com/download/)
@@ -54,7 +54,7 @@ Google Material Icon Font `<link href="https://fonts.googleapis.com/icon?family=
 ### bower
 
 	bower install bootstrap-material-datetimepicker
-	
+
 ### Parameters
 
 | Name				| Type							| Description									|
@@ -65,6 +65,7 @@ Google Material Icon Font `<link href="https://fonts.googleapis.com/icon?family=
 | **maxDate**		| (String\|Date\|Moment)		| Maximum selectable date						|
 | **currentDate**	| (String\|Date\|Moment)		| Initial Date									|
 | **date**			| Boolean						| true => Has Datepicker						|
+| **allowWeekends**	| Boolean						| true => Allow picking of weekends				|
 | **time**			| Boolean						| true => Has Timepicker						|
 | **clearButton**	| Boolean						| true => Show Clear Button						|
 | **nowButton**		| Boolean						| true => Show Now Button						|
@@ -96,5 +97,3 @@ Google Material Icon Font `<link href="https://fonts.googleapis.com/icon?family=
 | **setMinDate**	| (String\|Date\|Moment)	| Set minimum selectable date	|
 | **setMaxDate**	| (String\|Date\|Moment)	| Set maximum selectable date	|
 | **destroy**		| NULL						| Destroy the datepicker		|
-
-	

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Originaly designed for Bootstrap Material, the V2.0 is now completely standalone
 
 | Date				| Author			| Description											 |
 | ----------------- | ----------------- | ------------------------------------------------------ |
+| 2016-04-08		| donovansolms		| Disable specific days (#60 and #97)				 	 |
 | 2016-04-08		| T00rk				| Fixed #85	 								 	 		 |
 | 2016-04-08		| FoxyCorndog		| Fix PM overwrite bug	 					 	 		 |
 | 2016-02-17		| T00rk				| Changed Clock to SVG	 					 	 		 |
@@ -65,7 +66,7 @@ Google Material Icon Font `<link href="https://fonts.googleapis.com/icon?family=
 | **maxDate**		| (String\|Date\|Moment)		| Maximum selectable date						|
 | **currentDate**	| (String\|Date\|Moment)		| Initial Date									|
 | **date**			| Boolean						| true => Has Datepicker						|
-| **allowWeekends**	| Boolean						| true => Allow picking of weekends				|
+| **disabledDays**	| Array							| Array containing day indices (1-7) to disable	|
 | **time**			| Boolean						| true => Has Timepicker						|
 | **clearButton**	| Boolean						| true => Show Clear Button						|
 | **nowButton**		| Boolean						| true => Show Now Button						|
@@ -74,7 +75,7 @@ Google Material Icon Font `<link href="https://fonts.googleapis.com/icon?family=
 | **okText**		| String						| Text for the OK button (default: OK)			|
 | **clearText**		| String						| Text for the Clear button (default: Clear)	|
 | **nowText**		| String						| Text for the Now button (default: Now)		|
-| **triggerEvent**		| String						| Event to fire the calendar (default: focus)		|
+| **triggerEvent**	| String						| Event to fire the calendar (default: focus)	|
 
 
 

--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -17,7 +17,7 @@
       this.element = element;
       this.$element = $(element);
 
-       this.params = {date: true, time: true, format: 'YYYY-MM-DD', minDate: null, maxDate: null, currentDate: null, lang: 'en', weekStart: 0, allowWeekends: true, shortTime: false, clearButton: false, nowButton: false, cancelText: 'Cancel', okText: 'OK', clearText: 'Clear', nowText: 'Now', switchOnClick: false, triggerEvent: 'focus'};
+      this.params = {date: true, time: true, format: 'YYYY-MM-DD', minDate: null, maxDate: null, currentDate: null, lang: 'en', weekStart: 0, disabledDays: [], shortTime: false, clearButton: false, nowButton: false, cancelText: 'Cancel', okText: 'OK', clearText: 'Clear', nowText: 'Now', switchOnClick: false, triggerEvent: 'focus'};
       this.params = $.fn.extend(this.params, options);
 
       this.name = "dtp_" + this.setName();
@@ -719,24 +719,23 @@
                     _template += '<td data-date="' + moment(calendar.days[i]).locale(this.params.lang).format("D") + '">';
                     if (calendar.days[i] != 0)
                     {
-                       if (this.isBeforeMaxDate(moment(calendar.days[i]), false, false) === false || this.isAfterMinDate(moment(calendar.days[i]), false, false) === false)
-                       {
-                          _template += '<span class="dtp-select-day">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</span>';
-                       } else if (this.params.allowWeekends == false && calendar.days[i].isoWeekday() > 5)
-                       {
-                           _template += '<span class="dtp-select-day">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</span>';
-                       } else
-                       {
-                          if (moment(calendar.days[i]).locale(this.params.lang).format("DD") === moment(this.currentDate).locale(this.params.lang).format("DD"))
-                          {
-                             _template += '<a href="javascript:void(0);" class="dtp-select-day selected">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</a>';
-                          } else
-                          {
-                             _template += '<a href="javascript:void(0);" class="dtp-select-day">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</a>';
-                          }
-                       }
+                        if (this.isBeforeMaxDate(moment(calendar.days[i]), false, false) === false
+                            || this.isAfterMinDate(moment(calendar.days[i]), false, false) === false
+                            || this.params.disabledDays.indexOf(calendar.days[i].isoWeekday()) !== -1)
+                        {
+                            _template += '<span class="dtp-select-day">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</span>';
+                        } else
+                        {
+                            if (moment(calendar.days[i]).locale(this.params.lang).format("DD") === moment(this.currentDate).locale(this.params.lang).format("DD"))
+                            {
+                                _template += '<a href="javascript:void(0);" class="dtp-select-day selected">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</a>';
+                            } else
+                            {
+                                _template += '<a href="javascript:void(0);" class="dtp-select-day">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</a>';
+                            }
+                        }
 
-                       _template += '</td>';
+                        _template += '</td>';
                     }
                  }
                  _template += '</tr></tbody></table>';

--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -17,7 +17,7 @@
       this.element = element;
       this.$element = $(element);
 
-       this.params = {date: true, time: true, format: 'YYYY-MM-DD', minDate: null, maxDate: null, currentDate: null, lang: 'en', weekStart: 0, shortTime: false, clearButton: false, nowButton: false, cancelText: 'Cancel', okText: 'OK', clearText: 'Clear', nowText: 'Now', switchOnClick: false, triggerEvent: 'focus'};
+       this.params = {date: true, time: true, format: 'YYYY-MM-DD', minDate: null, maxDate: null, currentDate: null, lang: 'en', weekStart: 0, allowWeekends: true, shortTime: false, clearButton: false, nowButton: false, cancelText: 'Cancel', okText: 'OK', clearText: 'Clear', nowText: 'Now', switchOnClick: false, triggerEvent: 'focus'};
       this.params = $.fn.extend(this.params, options);
 
       this.name = "dtp_" + this.setName();
@@ -722,6 +722,9 @@
                        if (this.isBeforeMaxDate(moment(calendar.days[i]), false, false) === false || this.isAfterMinDate(moment(calendar.days[i]), false, false) === false)
                        {
                           _template += '<span class="dtp-select-day">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</span>';
+                       } else if (this.params.allowWeekends == false && calendar.days[i].isoWeekday() > 5)
+                       {
+                           _template += '<span class="dtp-select-day">' + moment(calendar.days[i]).locale(this.params.lang).format("DD") + '</span>';
                        } else
                        {
                           if (moment(calendar.days[i]).locale(this.params.lang).format("DD") === moment(this.currentDate).locale(this.params.lang).format("DD"))


### PR DESCRIPTION
This PR implements #60 and #97 in a very straightforward manner.

It adds the configuration option `disabledDays`, used as below to disable weekends:

```
$('#picker').bootstrapMaterialDatePicker({
     disabledDays: [6,7]
});
```
