### PR TITLE
Re-initialise after a destroy

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -44,7 +44,7 @@
             }
             if (options === 'destroy')
             {
-               delete $.data(this, pluginDataName);
+               $.removeData(this, pluginDataName);
             }
          }
       });


### PR DESCRIPTION
**Used jQuery.removeData instead of delete to allow re-initialisation of the datetime picker for the same element.**

I ran into a problem where I was unable to re-initialise a picker after destroying it. The delete keyword leaves the data in a weird state. Instead, if we use removeData, it works fine.