### PR TITLE
Fix mixed content issue on demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 			  href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/0.5.10/css/ripples.min.css"/>
 
 		<link rel="stylesheet" href="./css/bootstrap-material-datetimepicker.css" />
-		<link href='http://fonts.googleapis.com/css?family=Roboto:400,500' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Roboto:400,500' rel='stylesheet' type='text/css'>
 		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
 		<script src="https://code.jquery.com/jquery-1.12.3.min.js" integrity="sha256-aaODHAgvwQW1bFOGXMeX+pC4PZIPsvn2h1sArYOhgXQ=" crossorigin="anonymous"></script>
@@ -19,7 +19,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/0.5.10/js/ripples.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/0.5.10/js/material.min.js"></script>
 		<script type="text/javascript" src="https://rawgit.com/FezVrasta/bootstrap-material-design/master/dist/js/material.min.js"></script>
-		<script type="text/javascript" src="http://momentjs.com/downloads/moment-with-locales.min.js"></script>
+		<script type="text/javascript" src="https://momentjs.com/downloads/moment-with-locales.min.js"></script>
 		<script type="text/javascript" src="./js/bootstrap-material-datetimepicker.js"></script>
 
 		<style>


### PR DESCRIPTION
The demo page is currently not working because of Mixed Content errors.

> Mixed Content: The page at 'https://t00rk.github.io/bootstrap-material-datetimepicker/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Roboto:400,500'. This request has been blocked; the content must be served over HTTPS.

> Mixed Content: The page at 'https://t00rk.github.io/bootstrap-material-datetimepicker/' was loaded over HTTPS, but requested an insecure script 'http://momentjs.com/downloads/moment-with-locales.min.js'. This request has been blocked; the content must be served over HTTPS.

This fix the issue by loading remaining libraries with `https`.