### PR TITLE
Fix small bug in colors when select hour with mindate or maxdate.

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -1136,7 +1136,13 @@
                     var th = parent.find('.dtp-select-hour-text');
                     for (var i = 0; i < th.length; i++)
                     {
-                       $(th[i]).attr('fill', '#000');
+                       if (!this.toggleTime(i, true)) 
+                       {
+                         $(th[i]).attr('fill', '#bdbdbd');
+                       } else
+                       {
+                         $(th[i]).attr('fill', '#000');
+                       }
                     }
 
                     $(parent.find('#h-' + value)).attr('fill', '#8BC34A');
@@ -1172,7 +1178,13 @@
                     var tm = parent.find('.dtp-select-minute-text');
                     for (var i = 0; i < tm.length; i++)
                     {
-                       $(tm[i]).attr('fill', '#000');
+                       if (!this.toggleTime(i*5, false))
+                       {
+                         $(tm[i]).attr('fill', '#bdbdbd');
+                       } else
+                       {
+                         $(tm[i]).attr('fill', '#000');
+                       }
                     }
 
                     $(parent.find('#m-' + value)).attr('fill', '#8BC34A');


### PR DESCRIPTION
If you use a picker to select a hour or minute with mindate o maxdate, the first time the colours are good but when you select a hour or minute the min and repaint the numbers all are black.
![bug](https://user-images.githubusercontent.com/18242653/35477956-796f5d60-03d0-11e8-887f-3d61f64083a5.png)
