### PR TITLE
add container element option for datetimepicker

### DIFF
--- a/js/bootstrap-material-datetimepicker.js
+++ b/js/bootstrap-material-datetimepicker.js
@@ -18,7 +18,7 @@
       this.$element = $(element);
 
 
-      this.params = {date: true, time: true, format: 'YYYY-MM-DD', minDate: null, maxDate: null, currentDate: null, lang: 'en', weekStart: 0, disabledDays: [], shortTime: false, clearButton: false, nowButton: false, cancelText: 'Cancel', okText: 'OK', clearText: 'Clear', nowText: 'Now', switchOnClick: false, triggerEvent: 'focus', monthPicker: false, year:true};
+      this.params = {date: true, time: true, format: 'YYYY-MM-DD', minDate: null, maxDate: null, currentDate: null, lang: 'en', weekStart: 0, disabledDays: [], shortTime: false, clearButton: false, nowButton: false, cancelText: 'Cancel', okText: 'OK', clearText: 'Clear', nowText: 'Now', switchOnClick: false, triggerEvent: 'focus', monthPicker: false, year:true, container: 'body'};
       this.params = $.fn.extend(this.params, options);
 
       this.name = "dtp_" + this.setName();
@@ -277,7 +277,7 @@
 
                  if ($('body').find("#" + this.name).length <= 0)
                  {
-                    $('body').append(this.template);
+                    $(this.params.container).append(this.template);
 
                     if (this)
                        this.dtpElement = $('body').find("#" + this.name);


### PR DESCRIPTION
Before this commit, I've had a problem adding the datepicker to an input who as inside a dialog element. In chrome, the datepicker was behind dialog and no z-index could put the datepicker on top


![datetimebeforedialog](https://user-images.githubusercontent.com/13681785/37347365-6e242ff0-26b0-11e8-9e59-0199da465fb7.PNG)

after that I've added an option for the user could choose the element he wants to attach the datepicker making easier to handle such problems. I've added the dialog element as a container and it did work

![datetimeafterdialog](https://user-images.githubusercontent.com/13681785/37347499-bb1e4552-26b0-11e8-8eb6-2941a4f65008.PNG)

The body continues to be de default element for attaching the datepicker. One final word about this. Supplying a container option is kind of default for some datepicker libraries like [Pikday](https://github.com/dbushell/Pikaday)
