### PR TITLE
remove duplicated library loading from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
 		<script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/0.5.10/js/ripples.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/0.5.10/js/material.min.js"></script>
-		<script type="text/javascript" src="https://rawgit.com/FezVrasta/bootstrap-material-design/master/dist/js/material.min.js"></script>
 		<script type="text/javascript" src="http://momentjs.com/downloads/moment-with-locales.min.js"></script>
 		<script type="text/javascript" src="./js/bootstrap-material-datetimepicker.js"></script>
 


### PR DESCRIPTION
index.html loads "material.min.js" from both "cdnjs.cloudflare.com" and "rawgit.com",
and https://rawgit.com/FezVrasta/bootstrap-material-design/master/dist/js/material.min.js returns 404.